### PR TITLE
Add some missing and fix up some broken MIDI messages.

### DIFF
--- a/src/aseq.cpp
+++ b/src/aseq.cpp
@@ -140,12 +140,15 @@ namespace rtpmidid{
           DEBUG("Disconnected");
         }
         break;
-        case SND_SEQ_EVENT_NOTE:
+        //case SND_SEQ_EVENT_NOTE:
         case SND_SEQ_EVENT_NOTEOFF:
         case SND_SEQ_EVENT_NOTEON:
+        case SND_SEQ_EVENT_KEYPRESS:
         case SND_SEQ_EVENT_CONTROLLER:
         case SND_SEQ_EVENT_PGMCHANGE:
+        case SND_SEQ_EVENT_CHANPRESS:
         case SND_SEQ_EVENT_PITCHBEND:
+        case SND_SEQ_EVENT_SYSEX:
         {
           auto myport = ev->dest.port;
           for (auto &f: midi_event_callbacks[myport]){


### PR DESCRIPTION
@davidmoreno Thanks a *lot* for rtpmidid, I'm really happy that this exists now! We've been lacking RTP-MIDI support on Linux for quite some time now, and rtpmidid finally makes TouchDAW much easier to use on Linux.

While testing rtpmidid with TouchDAW, I did run into some issues, though, mostly because of missing MIDI messages. In particular, the scribble strips and the metering display in TouchDAW weren't working, so I added/fixed these, and also fixed some other bugs along the way. Details below. It would be great if this could be incorporated upstream. 

ALSA to RTP-MIDI:

- Remove the SND_SEQ_EVENT_NOTE events. These aren't real events and are only used when *outputting* note data through a queue, so that the note-off message is scheduled by ALSA automatically. We should never see this on input.

- Fixed up the broken note-off logic. Note-ons with velocity 0 would be translated to note-offs with zero velocity, which TouchDAW won't recognize at all. It's better to just leave the note-ons alone and transmit both note-ons and note-offs exactly as they are, which is what we do now.

- Make both channel and key pressure work. Channel pressure (which is used by the Mackie control protocol to transmit metering data) lacked a case in aseq::read_ready and key pressure (a.k.a. polyphonic aftertouch, status 0xAn) wasn't supported at all. This has now been fixed.

- Make sysex messages work. This is necessary to get the scribble strips working in TouchDAW (MCP uses this to transmit the channel description texts). To accommodate these, some buffer sizes were increased to 128 bytes in code invoking alsamidi_to_midiprotocol, so that moderately-sized sysex messages will go through without overflowing the buffers.

RTP-MIDI to ALSA:

- Implemented polyphonic aftertouch, and added a missing break statement for channel pressure in recv_rtpmidi_event.

- NOTE: *Receiving* sysex from RTP-MIDI still isn't implemented (although it shouldn't be too hard to do), as TouchDAW doesn't transmit these and so I wouldn't be able to test that functionality.