### PR TITLE
fix incompatible type errors

### DIFF
--- a/src/rtpclient.cpp
+++ b/src/rtpclient.cpp
@@ -147,7 +147,7 @@ void rtpclient::sendto(const parse_buffer_t &pb, rtppeer::port_e port){
     MSG_CONFIRM, (const struct sockaddr *)&peer_addr, sizeof(peer_addr)
   );
 
-  if (res != pb.capacity()){
+  if (res < 0 || static_cast<uint32_t>(res) != pb.capacity()){
     throw exception(
       "Could not send all data to {}:{}. Sent {}. {}",
       peer.remote_name, remote_base_port, res, strerror(errno)

--- a/src/rtpserver.cpp
+++ b/src/rtpserver.cpp
@@ -190,7 +190,7 @@ void rtpserver::sendto(const parse_buffer_t &pb, rtppeer::port_e port, struct so
     MSG_CONFIRM, (const struct sockaddr *)address, sizeof(struct sockaddr_in)
   );
 
-  if (res != pb.capacity()){
+  if (res < 0 || static_cast<uint32_t>(res) != pb.capacity()){
     throw exception(
       "Could not send all data. Sent {}. {}",
       res, strerror(errno)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -107,7 +107,8 @@ void test_client_t::send(rtpmidid::parse_buffer_t &msg){
 
   auto len = ::sendto(sockfd, msg.start, msg.size(), 0, (struct sockaddr *)&servaddr, sizeof(servaddr));
 
-  ASSERT_EQUAL(len, msg.size());
+  ASSERT_GTE(len,0);
+  ASSERT_EQUAL(static_cast<uint32_t>(len), msg.size());
 }
 
 void test_client_t::recv(rtpmidid::parse_buffer_t &msg){


### PR DESCRIPTION
sendto() returns ssize_t , which is an int, it returns -1 for error
pb.capacity, correctly is unsigned int.

this causes compilation issues on some platforms.


ps. with this PR, rtpmidid now compiles on raspberryPI (using raspbian buster), 
Im getting some issues, but I'll raise those as different issues and may send some PRs

 