### PR TITLE
fix #14, warn once for non-implemented midi messages

### DIFF
--- a/src/aseq.cpp
+++ b/src/aseq.cpp
@@ -157,8 +157,12 @@ namespace rtpmidid{
         }
         break;
         default:
-          DEBUG("This event type {} is not managed yet", ev->type);
-          break;
+	static bool warningRaised[SND_SEQ_EVENT_NONE+1];
+        if(!warningRaised[ev->type]) {
+          warningRaised[ev->type]=true; 
+          WARNING("This event type {} is not managed yet", ev->type);
+        }
+        break;
       }
 
     }

--- a/src/aseq.cpp
+++ b/src/aseq.cpp
@@ -149,6 +149,7 @@ namespace rtpmidid{
         case SND_SEQ_EVENT_CHANPRESS:
         case SND_SEQ_EVENT_PITCHBEND:
         case SND_SEQ_EVENT_SYSEX:
+        case SND_SEQ_EVENT_SENSING:
         {
           auto myport = ev->dest.port;
           for (auto &f: midi_event_callbacks[myport]){

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -168,6 +168,11 @@ void rtpmidid_t::setup_mdns(){
   mdns_rtpmidi.on_discovery([this](const std::string &name, const std::string &address, int32_t port){
     this->add_rtpmidi_client(name, address, port);
   });
+  
+  mdns_rtpmidi.on_removed([this](const std::string &name){
+    // TODO : remove client / alsa sessions
+    WARNING("NOT IMPLEMENTED : network browser removed client {} ", name);
+  });
 }
 
 

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -264,7 +264,7 @@ void rtpmidid_t::recv_rtpmidi_event(int port, parse_buffer_t &midi_data){
       case 0xD0:
         snd_seq_ev_clear(&ev);
         snd_seq_ev_set_chanpress(&ev, current_command & 0x0F, midi_data.read_uint8());
-	break;
+      break;
       case 0xE0:
       {
         snd_seq_ev_clear(&ev);
@@ -274,6 +274,11 @@ void rtpmidid_t::recv_rtpmidi_event(int port, parse_buffer_t &midi_data){
         // DEBUG("Pitch bend received {}", pitch_bend);
         snd_seq_ev_set_pitchbend(&ev, current_command & 0x0F, pitch_bend);
       }
+      break;
+      case 0xFE: //active sense
+        snd_seq_ev_clear(&ev);
+        snd_seq_ev_set_fixed(&ev);
+        ev.type = SND_SEQ_EVENT_SENSING;
       break;
       // XXXTODO: sysex
       default:
@@ -346,6 +351,9 @@ void rtpmidid_t::alsamidi_to_midiprotocol(snd_seq_event_t *ev, parse_buffer_t &s
       stream.write_uint8(0xE0 | (ev->data.control.channel & 0x0F));
       stream.write_uint8((ev->data.control.value + 8192) & 0x07F);
       stream.write_uint8((ev->data.control.value + 8192) >> 7 & 0x07F);
+    break;
+    case SND_SEQ_EVENT_SENSING:
+      stream.write_uint8(0xFE);
     break;
     case SND_SEQ_EVENT_SYSEX: {
       unsigned len = ev->data.ext.len, sz = stream.size();


### PR DESCRIPTION
stop crash when network session is removed - closes #14

warn only once when an unimplemented midi message is encountered. - so as to not clog up logs during development. (perhaps before 'released' this should be increased to ERROR level) 
 
implement active sensing closes #10 
 