### PR TITLE
rtpmidid::rtpserver constructor parameters wrong in rtpserver test

### DIFF
--- a/tests/test_rtpserver.cpp
+++ b/tests/test_rtpserver.cpp
@@ -37,7 +37,7 @@ auto connect_msg2 = hex_to_bin(
 
 void test_several_connect_to_server(){
   // random port
-  rtpmidid::rtpserver server("test", 0);
+  rtpmidid::rtpserver server("test", "0");
 
   DEBUG("Server port is {}", server.control_port);
 


### PR DESCRIPTION
rtpmidid::rtpserver constructor accepts std::string and const std::string& as parameters.

test_rtpserver.cpp line 40
rtpmidid::rtpserver server("test", 0); <-- integer here

Issue #21