### PR TITLE
Reuse same client port numbers for all connections 

### DIFF
--- a/include/rtpmidid/rtpclient.hpp
+++ b/include/rtpmidid/rtpclient.hpp
@@ -67,7 +67,7 @@ public:
   void reset();
   void sendto(const io_bytes &pb, rtppeer::port_e port);
 
-  void connect_to(const std::string &address, const std::string &port);
+  void connect_to(const std::string &address, const std::string &port, int local_port = -1);
   void connected();
   void send_ck0_with_timeout();
 

--- a/include/rtpmidid/rtpclient.hpp
+++ b/include/rtpmidid/rtpclient.hpp
@@ -24,6 +24,7 @@
 #include "./rtppeer.hpp"
 #include "./signal.hpp"
 #include <string>
+#include <optional>
 
 namespace rtpmidid {
 struct address_port_t {
@@ -58,6 +59,8 @@ public:
   /// A simple state machine. We need to send 6 CK one after another, and then
   /// every 10 secs.
   uint8_t timerstate;
+
+  std::optional<int> conn_event;
 
   rtpclient(std::string name);
   ~rtpclient();

--- a/lib/rtppeer.cpp
+++ b/lib/rtppeer.cpp
@@ -389,7 +389,7 @@ void rtppeer::parse_midi(io_bytes_reader &buffer) {
     WARNING("Received packet which is not RTP MIDI. Ignoring.");
     return;
   }
-  remote_seq_nr = buffer.read_uint16(); // Ignore RTP sequence no.
+  auto local_remote_seq_nr = buffer.read_uint16(); // Ignore RTP sequence no.
   // TODO In the future we may use a journal.
   // auto _remote_timestamp =
   buffer.read_uint32();                    // Ignore timestamp
@@ -399,6 +399,8 @@ void rtppeer::parse_midi(io_bytes_reader &buffer) {
     // not meant for this peer
     return;
   }
+  // copy sequence number only once we know it's for us.
+  remote_seq_nr = local_remote_seq_nr;
 
   // RFC 6295 RTP-MIDI _header
   // The Flags are:

--- a/lib/rtpserver.cpp
+++ b/lib/rtpserver.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<rtppeer> rtpserver::get_peer_by_packet(io_bytes_reader &buffer,
 void rtpserver::data_ready(rtppeer::port_e port) {
   uint8_t raw[1500];
   struct sockaddr_in6 cliaddr;
-  unsigned int len = sizeof(cliaddr);
+  socklen_t len = sizeof(cliaddr);
   auto socket = (port == rtppeer::CONTROL_PORT) ? control_socket : midi_socket;
   auto n = recvfrom(socket, raw, 1500, MSG_DONTWAIT,
                     (struct sockaddr *)&cliaddr, &len);
@@ -267,7 +267,6 @@ void rtpserver::sendto(const io_bytes_reader &pb, rtppeer::port_e port,
 void rtpserver::create_peer_from(io_bytes_reader &&buffer,
                                  struct sockaddr_in6 *cliaddr,
                                  rtppeer::port_e port) {
-
   auto peer = std::make_shared<rtppeer>(name);
   auto address = std::make_shared<struct sockaddr_in6>();
   ::memcpy(address.get(), cliaddr, sizeof(struct sockaddr_in6));

--- a/src/aseq.cpp
+++ b/src/aseq.cpp
@@ -140,6 +140,10 @@ void aseq::read_ready() {
     case SND_SEQ_EVENT_PITCHBEND:
     case SND_SEQ_EVENT_SYSEX:
     case SND_SEQ_EVENT_QFRAME:
+    case SND_SEQ_EVENT_START:
+    case SND_SEQ_EVENT_STOP:
+    case SND_SEQ_EVENT_CONTINUE:
+    case SND_SEQ_EVENT_CLOCK:
     case SND_SEQ_EVENT_SENSING: {
       auto myport = ev->dest.port;
       auto me = midi_event.find(myport);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -40,6 +40,7 @@ const char *CMDLINE_HELP =
     "  --version           Show version\n"
     "  --help              Show this help\n"
     "  --name <name>       Forces a rtpmidi name\n"
+    "  --exportname <name> Forces a name for exporting alsa. Default is Network.\n"
     "  --host <address>    My default IP. Needed to answer mDNS. Normally "
     "guessed but may be attached to another ip.\n"
     "  --port <port>       Opens local port as server. Default 5004. Can set "
@@ -58,6 +59,7 @@ const char *CMDLINE_HELP =
 typedef enum {
   ARG_NONE = 0,
   ARG_NAME,
+  ARG_EXPORT_NAME,
   ARG_HOST,
   ARG_PORT,
   ARG_CONNECT,
@@ -88,6 +90,8 @@ config_t rtpmidid::parse_cmd_args(int argc, char **argv) {
       }
       if (argname == "--name") {
         prevopt = ARG_NAME;
+      } else if (argname == "--exportname") {
+        prevopt = ARG_EXPORT_NAME;
       } else if (argname == "--host") {
         prevopt = ARG_HOST;
       } else if (argname == "--port") {
@@ -113,6 +117,10 @@ config_t rtpmidid::parse_cmd_args(int argc, char **argv) {
         opts.name = argv[i];
         INFO("Set RTP MIDI name to {}", opts.name);
         break;
+      case ARG_EXPORT_NAME:
+        opts.export_name = argv[i];
+        INFO("Set RTP MIDI export name to {}", opts.export_name);
+        break;
       case ARG_HOST:
         opts.host = argv[i];
         INFO("Set RTP MIDI listen host to {}", opts.host);
@@ -132,6 +140,10 @@ config_t rtpmidid::parse_cmd_args(int argc, char **argv) {
     char hostname[256];
     gethostname(hostname, std::size(hostname));
     opts.name = hostname;
+  }
+  
+  if (opts.export_name.size() == 0) {
+    opts.export_name = "Network";
   }
 
   if (opts.ports.size() == 0) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -32,6 +32,7 @@ extern const char *VERSION;
  */
 struct config_t {
   std::string name;
+  std::string export_name;
   std::vector<std::string> connect_to;
   // Create clients at this ports to start with. Later will see.
   std::vector<std::string> ports;

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -106,7 +106,7 @@ rtpmidid_t::add_rtpmidid_import_server(const std::string &name,
 
   auto wrtpserver = std::weak_ptr(rtpserver);
   rtpserver->connected_event.connect(
-      [this, wrtpserver, port](std::shared_ptr<::rtpmidid::rtppeer> peer) {
+      [this, wrtpserver, port] (std::shared_ptr<::rtpmidid::rtppeer> peer) {
         if (wrtpserver.expired()) {
           return;
         }
@@ -226,8 +226,8 @@ rtpmidid_t::add_rtpmidi_client(const std::string &name,
   for (auto &known : known_clients) {
     if (known.second.name == name) {
       // DEBUG(
-      //     "Trying to add again rtpmidi {}:{} server. Quite probably mDNS re
-      //     announce. " "Maybe somebody ask, or just periodically.", address,
+      //     "Trying to add again rtpmidi {}:{} server. Quite probably mDNS re"
+      //     "announce. " "Maybe somebody ask, or just periodically.", address,
       //     net_port
       // );
       known.second.addresses.push_back({address, net_port});
@@ -316,16 +316,18 @@ void rtpmidid_t::disconnect_client(int aseq_port, int reasoni) {
   switch (reason) {
   case rtppeer::disconnect_reason_e::CANT_CONNECT:
   case rtppeer::disconnect_reason_e::CONNECTION_REJECTED:
-    if (peer_info->connect_attempts >= (3 * peer_info->addresses.size())) {
+    if (peer_info->connect_attempts >= (8 * peer_info->addresses.size())) {
       ERROR("Too many attempts to connect. Not trying again. Attempted "
             "{} times.",
             peer_info->connect_attempts);
       remove_client(peer_info->aseq_port);
       return;
     }
+    
+    peer_info->peer->reset();
 
     peer_info->connect_attempts += 1;
-    peer_info->peer->connect_timer = poller.add_timer_event(1s, [peer_info] {
+    peer_info->peer->connect_timer = poller.add_timer_event(2s, [peer_info] {
       peer_info->addr_idx =
           (peer_info->addr_idx + 1) % peer_info->addresses.size();
       DEBUG("Try connect next in list. Idx {}/{}", peer_info->addr_idx,
@@ -542,6 +544,18 @@ void rtpmidid_t::alsamidi_to_midiprotocol(snd_seq_event_t *ev,
   case SND_SEQ_EVENT_QFRAME:
     stream.write_uint8(0xF1);
     stream.write_uint8(ev->data.control.value & 0x0FF);
+    break;
+  case SND_SEQ_EVENT_CLOCK:
+    stream.write_uint8(0xF8);
+    break;
+  case SND_SEQ_EVENT_START:
+    stream.write_uint8(0xFA);
+    break;
+  case SND_SEQ_EVENT_STOP:
+    stream.write_uint8(0xFC);
+    break;
+  case SND_SEQ_EVENT_CONTINUE:
+    stream.write_uint8(0xFB);
     break;
   default:
     WARNING("Event type not yet implemented! Not sending. {}", ev->type);

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -302,7 +302,8 @@ void rtpmidid_t::connect_client(const std::string &name, int aseq_port) {
         });
     peer_info->use_count++;
 
-    peer_info->peer->connect_to(address.address, address.port);
+    auto local_port = 50010;
+    peer_info->peer->connect_to(address.address, address.port, local_port);
   }
 }
 
@@ -452,6 +453,26 @@ void rtpmidid_t::recv_rtpmidi_event(int port, io_bytes_reader &midi_data) {
         snd_seq_ev_clear(&ev);
         snd_seq_ev_set_fixed(&ev);
         ev.type = SND_SEQ_EVENT_SENSING;
+        break;
+      case 0xF8: // Clock
+        snd_seq_ev_clear(&ev);
+        snd_seq_ev_set_fixed(&ev);
+        ev.type = SND_SEQ_EVENT_CLOCK;
+        break;
+      case 0xFA: // start
+        snd_seq_ev_clear(&ev);
+        snd_seq_ev_set_fixed(&ev);
+        ev.type = SND_SEQ_EVENT_START;
+        break;
+      case 0xFC: // stop
+        snd_seq_ev_clear(&ev);
+        snd_seq_ev_set_fixed(&ev);
+        ev.type = SND_SEQ_EVENT_STOP;
+        break;
+      case 0xFB: // continue
+        snd_seq_ev_clear(&ev);
+        snd_seq_ev_set_fixed(&ev);
+        ev.type = SND_SEQ_EVENT_CONTINUE;
         break;
       default:
         break;

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;
 rtpmidid_t::rtpmidid_t(config_t *config)
     : name(config->name), seq(fmt::format("rtpmidi {}", name)) {
   setup_mdns();
-  setup_alsa_seq();
+  setup_alsa_seq(config->export_name);
 
   for (auto &port : config->ports) {
     auto server = add_rtpmidid_import_server(config->name, port);
@@ -191,10 +191,10 @@ rtpmidid_t::add_rtpmidid_export_server(const std::string &name,
   return server;
 }
 
-void rtpmidid_t::setup_alsa_seq() {
+void rtpmidid_t::setup_alsa_seq(const std::string &name) {
   // Export only one, but all data that is conencted to it.
   // add_export_port();
-  auto alsaport = seq.create_port("Network");
+  auto alsaport = seq.create_port(name);
   seq.subscribe_event[alsaport].connect(
       [this, alsaport](aseq::port_t from, const std::string &name) {
         DEBUG("Connected to ALSA port {}:{}. Create network server for this "

--- a/src/rtpmidid.hpp
+++ b/src/rtpmidid.hpp
@@ -80,7 +80,7 @@ public:
 
   void alsamidi_to_midiprotocol(snd_seq_event_t *ev, io_bytes_writer &buffer);
 
-  void setup_alsa_seq();
+  void setup_alsa_seq(const std::string &name);
   void setup_mdns();
   void announce_rtpmidid_server(const std::string &name, uint16_t port);
   void unannounce_rtpmidid_server(const std::string &name, uint16_t port);


### PR DESCRIPTION
Disambiguation is done via ssrc. This allows connecting to multiple exported connections on the mioxl. 

There’s some other stuff in here like addicting midi clock message support and control of the service name. 

Likely the approach of multiple clients n-1 of which refuse mismatching ssrc is sub optimal. 