### PR TITLE
Something(?) gets swapped even if epoll_wait fails due to a signal.

### DIFF
--- a/lib/poller.cpp
+++ b/lib/poller.cpp
@@ -221,12 +221,14 @@ void poller_t::wait() {
     // }
   }
 
-  while (!pd->later_events.empty()) {
-    std::vector<std::function<void(void)>> call_now;
-    // Clean the later, get the now.
-    std::swap(call_now, pd->later_events);
-    for (auto &f : call_now) {
-      f();
+  if (nfds != -1) {
+    while (!pd->later_events.empty()) {
+      std::vector<std::function<void(void)>> call_now;
+      // Clean the later, get the now.
+      std::swap(call_now, pd->later_events);
+      for (auto &f : call_now) {
+        f();
+      }
     }
   }
 }


### PR DESCRIPTION
The epoll_wait man-page is (imho) slightly ambiguous but 'RETURN VALUE'
states that 0 is timeout and -1 is some error the EINTR I'm seeing
frequently.

It may be harmless currently, but maybe not in the future if other
changes are made.