### PR TITLE
Logging enhancement.

### DIFF
--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -338,7 +338,7 @@ void rtpmidid_t::disconnect_client(int aseq_port, int reasoni) {
 
   case rtppeer::disconnect_reason_e::CONNECT_TIMEOUT:
   case rtppeer::disconnect_reason_e::CK_TIMEOUT:
-    WARNING("Timeout (during %s). Not trying again.", reason == rtppeer::disconnect_reason_e::CK_TIMEOUT ? "handshake" : "setup");
+    WARNING("Timeout (during {}). Not trying again.", reason == rtppeer::disconnect_reason_e::CK_TIMEOUT ? "handshake" : "setup");
     remove_client(peer_info->aseq_port);
     return;
     break;

--- a/src/rtpmidid.cpp
+++ b/src/rtpmidid.cpp
@@ -338,7 +338,7 @@ void rtpmidid_t::disconnect_client(int aseq_port, int reasoni) {
 
   case rtppeer::disconnect_reason_e::CONNECT_TIMEOUT:
   case rtppeer::disconnect_reason_e::CK_TIMEOUT:
-    WARNING("Timeout. Not trying again.");
+    WARNING("Timeout (during %s). Not trying again.", reason == rtppeer::disconnect_reason_e::CK_TIMEOUT ? "handshake" : "setup");
     remove_client(peer_info->aseq_port);
     return;
     break;


### PR DESCRIPTION
rtppeer::disconnect_reason_e::CONNECT_TIMEOUT versus rtppeer::disconnect_reason_e::CK_TIMEOUT