### PR TITLE
failing sendto (e.g. by a signal) can cause the program to terminate

### DIFF
--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -250,11 +250,18 @@ void rtpclient::sendto(const io_bytes &pb, rtppeer::port_e port) {
     if (static_cast<uint32_t>(res) == pb.size())
       break;
 
-    if (res == -1 && errno == EINTR)
-      continue;
+    if (res == -1) {
+      if (errno == EINTR) {
+        DEBUG("Retry sendto because of EINTR");
+        continue;
+      }
 
-    throw exception("Could not send all data to {}:{}. Sent {}. {}",
+      throw exception("Could not send all data to {}:{}. Sent {}. {}",
                     peer.remote_name, remote_base_port, res, strerror(errno));
+    }
+
+    DEBUG("Could not send whole message: only {} of {}", res, pb.size());
+    break;
   }
 }
 

--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -245,7 +245,7 @@ void rtpclient::sendto(const io_bytes &pb, rtppeer::port_e port) {
   for(;;) {
     ssize_t res =
       ::sendto(socket, pb.start, pb.size(), MSG_CONFIRM,
-               (const struct sockaddr *)address, sizeof(struct sockaddr_in6));
+               (const struct sockaddr *)&peer_addr, sizeof(peer_addr));
 
     if (static_cast<uint32_t>(res) == pb.size())
       break;

--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -242,10 +242,17 @@ void rtpclient::sendto(const io_bytes &pb, rtppeer::port_e port) {
 
   auto socket = rtppeer::MIDI_PORT == port ? midi_socket : control_socket;
 
-  auto res = ::sendto(socket, pb.start, pb.size(), MSG_CONFIRM,
-                      (const struct sockaddr *)&peer_addr, sizeof(peer_addr));
+  for(;;) {
+    ssize_t res =
+      ::sendto(socket, pb.start, pb.size(), MSG_CONFIRM,
+               (const struct sockaddr *)address, sizeof(struct sockaddr_in6));
 
-  if (res < 0 || static_cast<uint32_t>(res) != pb.size()) {
+    if (static_cast<uint32_t>(res) == pb.size())
+      break;
+
+    if (res == -1 && errno == EINTR)
+      continue;
+
     throw exception("Could not send all data to {}:{}. Sent {}. {}",
                     peer.remote_name, remote_base_port, res, strerror(errno));
   }


### PR DESCRIPTION
Something occasionally causes an EINTR in rtpmidid (see also my pull-
request from epoll_wait). This could also cause ::sendto to 'fail' in
the rtpserver and rtpclient classes: sendto could then return -t with
errno set to EINTR. In that case one should/could "just retry" the
::sendto function call (unless the signal that caused the EINTR is not
indicating the application to stop - I don't know if that could be the
case here).