### PR TITLE
getnameinfo can fail but this is ignored

### DIFF
--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -97,8 +97,9 @@ void rtpclient::connect_to(const std::string &address,
     // we asusme that if the ocntrol success to be created the midi will too.
     auto serveraddr = sockaddress_list;
     for (; serveraddr != nullptr; serveraddr = serveraddr->ai_next) {
+      host[0] = service[0] = 0x00;
       getnameinfo(serveraddr->ai_addr, peer_addr_len, host, NI_MAXHOST, service,
-                  NI_MAXSERV, NI_NUMERICSERV);
+		      NI_MAXSERV, NI_NUMERICSERV);
       DEBUG("Try connect to resolved name: {}:{}", host, service);
       // remote_base_port = service;
 

--- a/lib/rtpserver.cpp
+++ b/lib/rtpserver.cpp
@@ -60,6 +60,7 @@ rtpserver::rtpserver(std::string _name, const std::string &port)
     socklen_t peer_addr_len = NI_MAXHOST;
     auto listenaddr = sockaddress_list;
     for (; listenaddr != nullptr; listenaddr = listenaddr->ai_next) {
+      host[0] = service[0] = 0x00;
       getnameinfo(listenaddr->ai_addr, peer_addr_len, host, NI_MAXHOST, service,
                   NI_MAXSERV, NI_NUMERICSERV);
       DEBUG("Try listen at {}:{}", host, service);
@@ -244,7 +245,7 @@ void rtpserver::data_ready(rtppeer::port_e port) {
         buffer.start[3] == 'N') {
       create_peer_from(std::move(buffer), &cliaddr, port);
     } else {
-      char host[NI_MAXHOST], service[NI_MAXSERV];
+      char host[NI_MAXHOST] { 0 }, service[NI_MAXSERV] { 0 };
       getnameinfo((const struct sockaddr *)&cliaddr, len, host, NI_MAXHOST,
 		      service, NI_MAXSERV, NI_NUMERICSERV);
 


### PR DESCRIPTION
If getnameinfo fails, at least don't return garbage or result from a previous invocation as that may confuse users.