### PR TITLE
When connected to a tty, use colors and print a timestamp and so on.

### DIFF
--- a/include/rtpmidid/logger.hpp
+++ b/include/rtpmidid/logger.hpp
@@ -50,6 +50,9 @@ enum LogLevel {
 };
 
 class logger {
+private:
+  bool is_a_terminal;
+
 public:
   logger();
   ~logger();

--- a/lib/logger.cpp
+++ b/lib/logger.cpp
@@ -48,11 +48,14 @@ std::string color(const std::string_view &str, Color color, Color bgcolor,
   return fmt::format("\033[{};{};{}m{}\033[0m", hl, color, bgcolor, str);
 }
 
-logger::logger() {}
+logger::logger() {
+	is_a_terminal = isatty(fileno(stdout));
+}
+
 logger::~logger() {}
 void logger::log(const char *filename, int lineno, LogLevel loglevel,
                  const std::string &msg) {
-  if (isatty(fileno(stdout))) {
+  if (is_a_terminal) {
     time_t now = time(nullptr);
     char timestamp[sizeof "2011-10-08T07:07:09Z"];
     strftime(timestamp, sizeof timestamp, "%FT%TZ", gmtime(&now));


### PR DESCRIPTION
When not connected to a tty, the program usually is logging through
syslog. In that case: do not use colors or a timestamp as syslog itself
is already providing a timestamp and escape-codes are half filtered (but
not completely) in syslog making things hard to read:

```
Aug 19 13:00:51 river rtpmidid[485]: #033[0;37m[2021-08-18T15:40:41Z] [rtpmidid.cpp:269]#033[0m Removing rtp midi client lappiemctopface
```

new:

```
Aug 19 21:53:12 lappiemctopface rtpmidid[78497]: [main.cpp:37] SIGTERM received. Closing.
```