### PR TITLE
logger: use 'stderr' instead of '::stderr'

### DIFF
--- a/lib/logger.cpp
+++ b/lib/logger.cpp
@@ -85,5 +85,5 @@ void logger::log(const char *filename, int lineno, LogLevel loglevel,
     fmt::print("[{}:{}] {}\n", filename, lineno, msg);
   }
 }
-void logger::flush() { ::fflush(::stderr); }
+void logger::flush() { ::fflush(stderr); }
 } // namespace logger


### PR DESCRIPTION
Use portable stderr macro to allow building on non-glibc platforms.

For example on OpenBSD:
```
 #define stderr  (&__sF[2])
```
Or when using the musl Standard C library's `stdio.h`:
```
 #define stderr (stderr)
```

resulting in:
```
[4/44] Building CXX object lib/CMakeFiles/rtpmidid-shared.dir/logger.cpp.o
FAILED: lib/CMakeFiles/rtpmidid-shared.dir/logger.cpp.o 
/usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/bin/arm-openwrt-linux-muslgnueabi-g++ -DRTPMIDID_VERSION=\"\" -Drtpmidid_shared_EXPORTS -I/usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/src -I/usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/include -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -mfloat-abi=hard -fmacro-prefix-map=/usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11=rtpmidid-21.11 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -DNDEBUG -fPIC   -std=gnu++17 -Wall -Werror -D_REENTRANT -MD -MT lib/CMakeFiles/rtpmidid-shared.dir/logger.cpp.o -MF lib/CMakeFiles/rtpmidid-shared.dir/logger.cpp.o.d -o lib/CMakeFiles/rtpmidid-shared.dir/logger.cpp.o -c /usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/lib/logger.cpp
In file included from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/cstdio:42,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/ext/string_conversions.h:43,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/bits/basic_string.h:6608,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/string:55,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/bits/locale_classes.h:40,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/bits/ios_base.h:41,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/ios:42,
                 from /usr/src/lede/staging_dir/toolchain-arm_cortex-a7+neon-vfpv4_gcc-11.3.0_musl_eabi/arm-openwrt-linux-muslgnueabi/include/c++/11.3.0/ostream:38,
                 from /usr/src/lede/staging_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/usr/include/fmt/ostream.h:11,
                 from /usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/lib/logger.cpp:20:
/usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/lib/logger.cpp: In member function 'void logger::logger::flush()':
/usr/src/lede/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/rtpmidid-21.11/lib/logger.cpp:88:35: error: expected id-expression before '(' token
   88 | void logger::flush() { ::fflush(::stderr); }
      |                                   ^~~~~~
```

