### PR TITLE
test_rtpmidid: don't include bits directly

### DIFF
--- a/tests/test_rtpmidid.cpp
+++ b/tests/test_rtpmidid.cpp
@@ -1,4 +1,4 @@
-#include <bits/stdint-uintn.h>
+#include <cstdint>
 #include <chrono>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Include `<stdint.h>` instead of `<bits/stdint-uintn.h>` which is specific to the GNU C library and may not exist in other implementations.