### PR TITLE
Use CLOCK_MONOTONIC for timestamping messages

### DIFF
--- a/lib/rtppeer.cpp
+++ b/lib/rtppeer.cpp
@@ -582,7 +582,7 @@ void rtppeer::parse_sysex(io_bytes_reader &buffer, int16_t length) {
 uint64_t rtppeer::get_timestamp() {
   struct timespec spec;
 
-  clock_gettime(CLOCK_REALTIME, &spec);
+  clock_gettime(CLOCK_MONOTONIC, &spec);
   // ns is 1e-9s. I need 1e-4s, so / 1e5
   uint64_t now = spec.tv_sec * 10000 + spec.tv_nsec / 1.0e5;
   // DEBUG("{}s {}ns", spec.tv_sec, spec.tv_nsec);


### PR DESCRIPTION
Since message timestamps are not related to wall clock, and are used for latency computations, we should use CLOCK_MONOTONIC instead of CLOCK_REALTIME. Wall clock (CLOCK_REALTIME) is not reliable for duration computations.