### PR TITLE
Fix RTP MIDI List parsing: delta time and MIDI command running status

### DIFF
--- a/include/rtpmidid/rtppeer.hpp
+++ b/include/rtpmidid/rtppeer.hpp
@@ -82,6 +82,7 @@ public:
   uint64_t timestamp_start; // Time in ms
   uint64_t latency;
   bool waiting_ck;
+  uint8_t running_status;
   // Need some buffer space for sysex. This may require memory alloc.
   std::vector<uint8_t> sysex;
 
@@ -122,6 +123,7 @@ public:
   void parse_command_by(io_bytes_reader &, port_e port);
   void parse_command_no(io_bytes_reader &, port_e port);
   static int read_delta_time(io_bytes_reader &, uint32_t &delta_time);
+  int next_midi_packet_length(io_bytes_reader &);
   void parse_midi(io_bytes_reader &);
   void parse_sysex(io_bytes_reader &, int16_t length);
 

--- a/include/rtpmidid/rtppeer.hpp
+++ b/include/rtpmidid/rtppeer.hpp
@@ -121,6 +121,7 @@ public:
   void parse_command_ck(io_bytes_reader &, port_e port);
   void parse_command_by(io_bytes_reader &, port_e port);
   void parse_command_no(io_bytes_reader &, port_e port);
+  static int read_delta_time(io_bytes_reader &, uint32_t &delta_time);
   void parse_midi(io_bytes_reader &);
   void parse_sysex(io_bytes_reader &, int16_t length);
 

--- a/tests/test_rtppeer.cpp
+++ b/tests/test_rtppeer.cpp
@@ -193,10 +193,9 @@ void test_recv_some_midi() {
   peer.data_ready(hex_to_bin("[1000 0001] [0110 0001] 'SQ'"
                              "00 00 00 00"
                              "'BEEF'"
-                             "07"
-                             "90 64 7F 90 7F 71 F8" // No Journal, 7 bytes, Two
-                                                    // note ons and one clock
-                             ),
+                             "0B"                               // No Journal, 11 bytes
+                             "90 64 7F 00 90 7F 71 80 80 00 F8" // Two note ons and one clock
+                             ),                                 // Delta times zero (2 different encodings)
                   rtpmidid::rtppeer::MIDI_PORT);
 
   ASSERT_EQUAL(got_midi_nr, 3);
@@ -307,7 +306,7 @@ void test_send_large_sysex(void) {
       "F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 "
       "F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 "
       "F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F0 00 F7 F7"
-      "F0"
+      "00 F0"
       "44 01 47 57 2D "
       "00 00 0D 33 17 00 3E 0C 48 31 01 09 44 12 04 40 00 2E 1F 34 1F 2B 69 60 "
       "00 04 18 F0 00 F7 44 01 47 57 2D 00 00 0D 33 17 00 3E 0C 48 31 01 09 44 "


### PR DESCRIPTION
This PR fixes two problems in the processing of RTP MIDI packets with multiple MIDI messages in `rtppeer.cpp`:
- Fix the decoding of variable length delta times between messages accordingly to page 16 of RFC 6295.
- Only the first MIDI message in the list is required to include status byte, the following may use the running status coding (RFC 6295, p.17). We now take this into account to infer messages sizes, and to recover full commands (with status byte) before passing them to `rtpmidid.cpp`.
- Fix the existing test messages for multi-command (the mandatory delta-time was missing between commands) and large sysex.
- Provide another test case for multi-command with running status (the MIDI list data is extracted from iPhone generated RTP MIDI).