### PR TITLE
Minor fix for debug output

### DIFF
--- a/lib/rtppeer.cpp
+++ b/lib/rtppeer.cpp
@@ -232,7 +232,7 @@ void rtppeer::parse_command_by(io_bytes_reader &buffer, port_e port) {
     return;
   }
 
-  DEBUG("status: {}, port {} (midi: %d)", status, port, port == MIDI_PORT);
+  DEBUG("status: {}, port {} (midi: {})", status, port, port == MIDI_PORT);
 
   status = (status_e)(((int)status) &
                       ~((int)(port == MIDI_PORT ? MIDI_CONNECTED


### PR DESCRIPTION
Not sure if this is the correct format (perhaps should be a boolean?) but %d is being output as a literal string.