### PR TITLE
systemd: Wants instead of After avahi-daemon

### DIFF
--- a/debian/rtpmidid.service
+++ b/debian/rtpmidid.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=rtpmidid
-After=avahi-daemon.service
+Wants=avahi-daemon.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
After= does not start avahi-daemon. It only defines the order.

Wants= defines a dependency (what it is).

$ man systemd.unit