### PR TITLE
Add cmake option to compile libraries only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ option(USE_CLANG "Use clang compiler" OFF)
 option(USE_LINKER_MOLD "Use mold linker" OFF)
 # option to enable lld linker
 option(USE_LINKER_LLD "Use lld linker" OFF)
+# option to only build shared and static libraries
+option(LIBS_ONLY "Only build libraries" OFF)
 
 
 if (USE_CLANG)
@@ -69,7 +71,9 @@ endif(ENABLE_PCH)
 include(FindPkgConfig)
 pkg_check_modules(AVAHI REQUIRED avahi-client)
 pkg_check_modules(FMT REQUIRED fmt)
-pkg_check_modules(ALSA REQUIRED alsa)
+if(NOT LIBS_ONLY)
+  pkg_check_modules(ALSA REQUIRED alsa)
+endif(NOT LIBS_ONLY)
 
 
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/include)
@@ -83,7 +87,9 @@ add_definitions(-DRTPMIDID_VERSION=\"${RTPMIDID_VERSION}\")
 message(STATUS "Version ${RTPMIDID_VERSION}")
 
 add_subdirectory(lib)
-add_subdirectory(src)
+if(NOT LIBS_ONLY)
+  add_subdirectory(src)
+endif(NOT LIBS_ONLY)
 
 if (ENABLE_TESTS STREQUAL "ON")
   add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,27 +44,31 @@ add_test(NAME test_signals COMMAND test_signals)
 # MIDIROUTER
 # 
 
-add_executable(test_midirouter
-    test_midirouter.cpp test_utils.cpp 
-)
-target_link_libraries(test_midirouter -lfmt -pthread rtpmidid-shared rtpmidid2-static)
-add_test(NAME test_midirouter COMMAND test_midirouter)
-target_link_libraries(test_midirouter ${ALSA_LIBRARIES})
-target_include_directories(test_midirouter PUBLIC ${ALSA_INCLUDE_DIRS})
-target_compile_options(test_midirouter PUBLIC ${ALSA_CFLAGS_OTHER})
+if (NOT LIBS_ONLY)
+  add_executable(test_midirouter
+      test_midirouter.cpp test_utils.cpp
+  )
+  target_link_libraries(test_midirouter -lfmt -pthread rtpmidid-shared rtpmidid2-static)
+  add_test(NAME test_midirouter COMMAND test_midirouter)
+  target_link_libraries(test_midirouter ${ALSA_LIBRARIES})
+  target_include_directories(test_midirouter PUBLIC ${ALSA_INCLUDE_DIRS})
+  target_compile_options(test_midirouter PUBLIC ${ALSA_CFLAGS_OTHER})
+endif (NOT LIBS_ONLY)
 
 #
 # MIDIROUTER2
 # 
 
-add_executable(test_midirouter2
-    test_midirouter2.cpp test_utils.cpp 
+if (NOT LIBS_ONLY)
+  add_executable(test_midirouter2
+      test_midirouter2.cpp test_utils.cpp
   )
-target_link_libraries(test_midirouter2 -lfmt -pthread rtpmidid-shared rtpmidid2-static)
-add_test(NAME test_midirouter2 COMMAND test_midirouter2)
-target_link_libraries(test_midirouter2 ${ALSA_LIBRARIES})
-target_include_directories(test_midirouter2 PUBLIC ${ALSA_INCLUDE_DIRS})
-target_compile_options(test_midirouter2 PUBLIC ${ALSA_CFLAGS_OTHER})
+  target_link_libraries(test_midirouter2 -lfmt -pthread rtpmidid-shared rtpmidid2-static)
+  add_test(NAME test_midirouter2 COMMAND test_midirouter2)
+  target_link_libraries(test_midirouter2 ${ALSA_LIBRARIES})
+  target_include_directories(test_midirouter2 PUBLIC ${ALSA_INCLUDE_DIRS})
+  target_compile_options(test_midirouter2 PUBLIC ${ALSA_CFLAGS_OTHER})
+endif (NOT LIBS_ONLY)
 
 
 # disabled as failing 


### PR DESCRIPTION
When using the libraries outside the rtpmidid daemon, it is useful not to have to build the daemon, because it pulls in alsa libs as dependencies.