### PR TITLE
Fix `make install` path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,41 +125,41 @@ ifneq ($(DESTDIR),)
     PREFIX := $(DESTDIR)
 endif
 ifeq ($(PREFIX),)
-    PREFIX := /usr/local/
+    PREFIX := /usr/local
 endif
 .PHONY: install
 
 install: install-rtpmidid install-librtpmidid0 install-librtpmidid0-dev
 
 install-rtpmidid: build man
-	mkdir -p $(PREFIX)/usr/bin/
-	cp build/src/rtpmidid $(PREFIX)/usr/bin/
+	mkdir -p $(PREFIX)/bin/
+	cp build/src/rtpmidid $(PREFIX)/bin/
 	cd cli && make compile
-	cp build/rtpmidid-cli $(PREFIX)/usr/bin/rtpmidid-cli
+	cp build/rtpmidid-cli $(PREFIX)/bin/rtpmidid-cli
 	mkdir -p $(PREFIX)/etc/systemd/system/
 	cp debian/rtpmidid.service $(PREFIX)/etc/systemd/system/
 	mkdir -p $(PREFIX)/etc/rtpmidid/
 	cp default.ini $(PREFIX)/etc/rtpmidid/
-	mkdir -p $(PREFIX)/usr/share/doc/rtpmidid/
-	cp README.md $(PREFIX)/usr/share/doc/rtpmidid/
-	cp LICENSE-daemon.txt $(PREFIX)/usr/share/doc/rtpmidid/LICENSE.txt
-	mkdir -p $(PREFIX)/usr/share/man/man1/
-	cp build/man/rtpmidid.1 $(PREFIX)/usr/share/man/man1/
-	cp build/man/rtpmidid-cli.1 $(PREFIX)/usr/share/man/man1/
+	mkdir -p $(PREFIX)/share/doc/rtpmidid/
+	cp README.md $(PREFIX)/share/doc/rtpmidid/
+	cp LICENSE-daemon.txt $(PREFIX)/share/doc/rtpmidid/LICENSE.txt
+	mkdir -p $(PREFIX)/share/man/man1/
+	cp build/man/rtpmidid.1 $(PREFIX)/share/man/man1/
+	cp build/man/rtpmidid-cli.1 $(PREFIX)/share/man/man1/
 
 install-librtpmidid0: build
-	mkdir -p $(PREFIX)/usr/lib/
-	cp -a build/lib/lib*so* $(PREFIX)/usr/lib/
-	mkdir -p $(PREFIX)/usr/share/doc/librtpmidid0/
-	cp README.md $(PREFIX)/usr/share/doc/librtpmidid0/
-	cp README.librtpmidid.md $(PREFIX)/usr/share/doc/librtpmidid0/
-	cp LICENSE-lib.txt $(PREFIX)/usr/share/doc/librtpmidid0/LICENSE.txt
+	mkdir -p $(PREFIX)/lib/
+	cp -a build/lib/lib*so* $(PREFIX)/lib/
+	mkdir -p $(PREFIX)/share/doc/librtpmidid0/
+	cp README.md $(PREFIX)/share/doc/librtpmidid0/
+	cp README.librtpmidid.md $(PREFIX)/share/doc/librtpmidid0/
+	cp LICENSE-lib.txt $(PREFIX)/share/doc/librtpmidid0/LICENSE.txt
 
 install-librtpmidid0-dev: build
-	mkdir -p $(PREFIX)/usr/lib/ $(PREFIX)/usr/include/
-	cp -a build/lib/lib*.a $(PREFIX)/usr/lib/
-	cp -a include/rtpmidid $(PREFIX)/usr/include/
-	mkdir -p $(PREFIX)/usr/share/doc/librtpmidid0-dev/
-	cp README.md $(PREFIX)/usr/share/doc/librtpmidid0-dev/
-	cp README.librtpmidid.md $(PREFIX)/usr/share/doc/librtpmidid0-dev/
-	cp LICENSE-lib.txt $(PREFIX)/usr/share/doc/librtpmidid0-dev/LICENSE.txt
+	mkdir -p $(PREFIX)/lib/ $(PREFIX)/include/
+	cp -a build/lib/lib*.a $(PREFIX)/lib/
+	cp -a include/rtpmidid $(PREFIX)/include/
+	mkdir -p $(PREFIX)/share/doc/librtpmidid0-dev/
+	cp README.md $(PREFIX)/share/doc/librtpmidid0-dev/
+	cp README.librtpmidid.md $(PREFIX)/share/doc/librtpmidid0-dev/
+	cp LICENSE-lib.txt $(PREFIX)/share/doc/librtpmidid0-dev/LICENSE.txt


### PR DESCRIPTION
The installation paths should not include an additional `/usr`, as this leads to incorrect directory structures. For example, when `PREFIX='/usr/local'` is set, the `bin` directory is incorrectly installed to `/usr/local/usr/bin`, but it should instead be placed in `/usr/local/bin`.

This PR fixes the paths to be as expected.