### PR TITLE
fix compilation with fmt v11

### DIFF
--- a/include/rtpmidid/poller.hpp
+++ b/include/rtpmidid/poller.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <functional>
 #include <optional>
+#include <memory>
 
 // #define DEBUG0 DEBUG
 #define DEBUG0(...)

--- a/include/rtpmidid/rtpclient.hpp
+++ b/include/rtpmidid/rtpclient.hpp
@@ -143,7 +143,7 @@ struct fmt::formatter<std::list<rtpmidid::rtpclient_t::endpoint_t>>
 template <>
 struct fmt::formatter<rtpmidid::rtpclient_t::state_e>
     : formatter<fmt::string_view> {
-  auto format(const rtpmidid::rtpclient_t::state_e &data, format_context &ctx) {
+  auto format(rtpmidid::rtpclient_t::state_e &data, format_context &ctx) const {
     const char *ret = rtpmidid::rtpclient_t::to_string(data);
     return formatter<fmt::string_view>::format(ret, ctx);
   }
@@ -153,7 +153,7 @@ struct fmt::formatter<rtpmidid::rtpclient_t::state_e>
 template <>
 struct fmt::formatter<rtpmidid::rtpclient_t::event_e>
     : formatter<fmt::string_view> {
-  auto format(const rtpmidid::rtpclient_t::event_e &data, format_context &ctx) {
+  auto format(rtpmidid::rtpclient_t::event_e &data, format_context &ctx) const {
     const char *ret = rtpmidid::rtpclient_t::to_string(data);
     return formatter<fmt::string_view>::format(ret, ctx);
   }

--- a/include/rtpmidid/signal.hpp
+++ b/include/rtpmidid/signal.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 
 // #define DEBUG0 DEBUG
 #define DEBUG0(...)


### PR DESCRIPTION
This change fixes compilation with fmt v11, with broke with the update. I can't see how this would break anything with the stock setup, but let me know if it does. Thanks!