### PR TITLE
Add option for disabling mdns service browser

### DIFF
--- a/include/rtpmidid/mdns_rtpmidi.hpp
+++ b/include/rtpmidid/mdns_rtpmidi.hpp
@@ -67,8 +67,9 @@ public:
   poller_t::listener_t watch_out_poller;
   poller_t::timer_t reconnect_timer;
   int announce_suffix = 0;
+  bool enable_service_browser = true;
 
-  mdns_rtpmidi_t();
+  mdns_rtpmidi_t(bool enable_service_browser = false);
   ~mdns_rtpmidi_t();
 
   void connect_to_avahi();

--- a/lib/mdns_rtpmidi.cpp
+++ b/lib/mdns_rtpmidi.cpp
@@ -271,7 +271,7 @@ static void browse_callback(AvahiServiceBrowser *b, AvahiIfIndex interface,
   mr->browse_callback(data);
 }
 
-rtpmidid::mdns_rtpmidi_t::mdns_rtpmidi_t() {
+rtpmidid::mdns_rtpmidi_t::mdns_rtpmidi_t(bool enable_service_browser) : enable_service_browser{false} {
   current = this;
 
   service_browser = nullptr;
@@ -367,7 +367,9 @@ void rtpmidid::mdns_rtpmidi_t::client_callback(avahi_client_state_e state_) {
     /* The server has startup successfully and registered its host
      * name on the network, so it's time to create our services */
     INFO("Client running");
-    setup_service_browser();
+    if (enable_service_browser) {
+      setup_service_browser();
+    }
     setup_entry_group();
     break;
   case AVAHI_CLIENT_FAILURE: {

--- a/src/argv.cpp
+++ b/src/argv.cpp
@@ -154,6 +154,12 @@ static std::vector<argument_t> setup_arguments() {
       "Creates a control socket. Check CONTROL.md. Default "
       "`/var/run/rtpmidid/control.sock`",
       [](const std::string &value) { settings.control_filename = value; });
+  arguments.emplace_back(
+      "--create-client-ports",
+      "Creates alsa port for each announced client. Default true.",
+      [](const std::string &value) {
+        std::istringstream(value) >> std::boolalpha >> settings.create_ports_for_clients;
+        });
   arguments.emplace_back( //
       "--version",        //
       "Show version", [](const std::string &value) {

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -125,6 +125,8 @@ void load_ini(const std::string &filename) {
         settings.alsa_name = value;
       } else if (key == "control") {
         settings.control_filename = value;
+      } else if (key == "create_ports_for_clients") {
+        std::istringstream(value) >> std::boolalpha >> settings.create_ports_for_clients;
       } else {
         throw rtpmidid::ini_exception(filename, lineno, "Invalid key: {}", key);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,12 +72,15 @@ public:
       aseq =
           std::make_shared<rtpmididns::aseq_t>(rtpmididns::settings.alsa_name);
     if (rtpmididns::mdns.get() == nullptr)
-      rtpmididns::mdns = std::make_unique<rtpmidid::mdns_rtpmidi_t>();
+      rtpmididns::mdns = std::make_unique<rtpmidid::mdns_rtpmidi_t>(rtpmididns::settings.create_ports_for_clients);
     router = std::make_shared<rtpmididns::midirouter_t>();
     control.router = router;
     control.aseq = aseq;
     control.mdns = rtpmididns::mdns;
-    rtpmididns::rtpmidi_remote_handler_t rtpmidi_remote_handler(router, aseq);
+    if (rtpmididns::settings.create_ports_for_clients) {
+      // Question: Does this not get deleted once leaving scope?
+      rtpmididns::rtpmidi_remote_handler_t rtpmidi_remote_handler(router, aseq);
+    }
 
     setup_local_alsa_multilistener();
     setup_network_rtpmidi_multilistener();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -101,11 +101,11 @@ fmt::appender fmt::formatter<rtpmididns::settings_t>::format(
                         "[settings_t: alsa_name: {}, alsa_network: {}, "
                         "control_filename: {}, rtpmidi_announces: {}, "
                         "alsa_announces: {}, connect_to: {}, "
-                        "alsa_hw_auto_export: {}, rawmidi: {}]",
+                        "alsa_hw_auto_export: {}, rawmidi: {}, create_ports_for_clients: {}]",
                         data.alsa_name, data.alsa_network,
                         data.control_filename, data.rtpmidi_announces,
                         data.alsa_announces, data.connect_to,
-                        data.alsa_hw_auto_export, data.rawmidi);
+                        data.alsa_hw_auto_export, data.rawmidi, data.create_ports_for_clients);
 #else
   return fmt::format_to(ctx.out(), "[settings_t]");
 #endif

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -28,6 +28,7 @@ struct settings_t {
   std::string alsa_name = "rtpmidid";
   bool alsa_network = true;
   std::string control_filename = "/var/run/rtpmidid/control.sock";
+  bool create_ports_for_clients = true;
 
   // Datas a read from the ini file
   struct rtpmidi_announce_t {


### PR DESCRIPTION
Runtime option for disabling mdns service browser, thus not creating alsa ports for clients.