### PR TITLE
Fix rtpmidid client not building

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -21,7 +21,28 @@
 
 namespace rtpmididns {
 settings_t settings;
+
+std::string format_as(rtpmididns::settings_t::alsa_hw_auto_export_type_e data) {
+  std::string result = "[";
+  if (data == rtpmididns::settings_t::alsa_hw_auto_export_type_e::NONE) {
+    result += "NONE";
+  } else if (data == rtpmididns::settings_t::alsa_hw_auto_export_type_e::ALL) {
+    result += "ALL";
+  } else {
+    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::HARDWARE) {
+      result += "HARDWARE ";
+    }
+    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::SOFTWARE) {
+      result += "SOFTWARE ";
+    }
+    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::SYSTEM) {
+      result += "SYSTEM ";
+    }
+  }
+  result += "]";
+  return result;
 }
+} // namespace rtpmididns
 
 fmt::appender fmt::formatter<rtpmididns::settings_t::alsa_announce_t>::format(
     const rtpmididns::settings_t::alsa_announce_t &data,
@@ -131,24 +152,3 @@ fmt::formatter<rtpmididns::settings_t::alsa_hw_auto_export_t>::format(
   return fmt::format_to(ctx.out(), "{}", result);
 }
 
-std::string
-format_as(const rtpmididns::settings_t::alsa_hw_auto_export_type_e data) {
-  std::string result = "[";
-  if (data == rtpmididns::settings_t::alsa_hw_auto_export_type_e::NONE) {
-    result += "NONE";
-  } else if (data == rtpmididns::settings_t::alsa_hw_auto_export_type_e::ALL) {
-    result += "ALL";
-  } else {
-    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::HARDWARE) {
-      result += "HARDWARE ";
-    }
-    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::SOFTWARE) {
-      result += "SOFTWARE ";
-    }
-    if (data & rtpmididns::settings_t::alsa_hw_auto_export_type_e::SYSTEM) {
-      result += "SYSTEM ";
-    }
-  }
-  result += "]";
-  return result;
-}

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -86,6 +86,8 @@ struct settings_t {
   std::vector<rawmidi_t> rawmidi;
 };
 
+std::string format_as(rtpmididns::settings_t::alsa_hw_auto_export_type_e data);
+
 extern settings_t settings; // NOLINT
 } // namespace rtpmididns
 
@@ -147,9 +149,6 @@ struct fmt::formatter<rtpmididns::settings_t::alsa_hw_auto_export_t>
   format(const rtpmididns::settings_t::alsa_hw_auto_export_t &data,
          format_context &ctx) const;
 };
-
-std::string
-format_as(const rtpmididns::settings_t::alsa_hw_auto_export_type_e data);
 
 template <>
 struct fmt::formatter<std::vector<rtpmididns::settings_t::rawmidi_t>>


### PR DESCRIPTION
When building with gcc 14.2.1 and libfmt 11.0.2 I get the following error:
```
[ 35%] Building CXX object src/CMakeFiles/rtpmidid2-static.dir/settings.cpp.o
In file included from /usr/include/fmt/format.h:41,
                 from rtpmidid/include/rtpmidid/logger.hpp:23,
                 from rtpmidid/src/midipeer.hpp:22,
                 from rtpmidid/src/precompile.hpp:23,
                 from rtpmidid/build/src/CMakeFiles/rtpmidid2-static.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/fmt/base.h: In instantiation of ‘constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = const rtpmididns::settings_t::alsa_hw_auto_export_type_e; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’:
/usr/include/fmt/base.h:2018:74:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {const rtpmididns::settings_t::alsa_hw_auto_export_type_e}; long unsigned int NUM_ARGS = 1; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 15; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
 2018 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2019 |       args)...}};
      |       ~~~~~
/usr/include/fmt/format.h:4365:44:   required from ‘std::string fmt::v11::format(format_string<T ...>, T&& ...) [with T = {const rtpmididns::settings_t::alsa_hw_auto_export_type_e&}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, const rtpmididns::settings_t::alsa_hw_auto_export_type_e&>]’
 4365 |   return vformat(fmt, fmt::make_format_args(args...));
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
rtpmidid/src/settings.cpp:129:24:   required from here
  129 |   result += fmt::format("type: {} ", data.type);
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1641:63: error: ‘fmt::v11::detail::type_is_unformattable_for<const rtpmididns::settings_t::alsa_hw_auto_export_type_e, char> _’ has incomplete type
 1641 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
/usr/include/fmt/base.h:1644:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1644 |       formattable,
```
It seems libfmt does not like format_as to be in a different namespace. This moves the function into the rtpmididns namespace.

Alternatively I could also implement the template specialization.