### PR TITLE
Add build options for logger verbosity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ set(CPP_VERSION "auto" CACHE STRING "Use given C++  version. 17 and 20 supported
 # option to force use fmt, depends on CPP20
 set(USE_FMT "auto" CACHE STRING "Use fmt library (ON | OFF | auto)")
 
+set(LOG_LEVEL "Debug" CACHE STRING "Set log level (Debug | Info | Warning | Error)")
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/rtpmidid/buildoptions.hpp.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/rtpmidid/buildoptions.hpp"
+)
+
 # if CPP is "auto", check if C++20 is available and set it
 if (CPP_VERSION STREQUAL "auto" OR CPP_VERSION STREQUAL "auto")
   message(STATUS "Checking for C++20 support")

--- a/include/rtpmidid/buildoptions.hpp
+++ b/include/rtpmidid/buildoptions.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+// clang-format off
+#define LOG_LEVEL log_level_t::Error
+// clang-format on
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL log_level_t::Debug
+#endif
+
+namespace rtpmidid {
+enum class log_level_t { Debug, Info, Warning, Error };
+
+
+struct build_options_t {
+  constexpr static int log_level = static_cast<int>(LOG_LEVEL);
+};
+} // namespace rtpmidid
+
+inline constexpr rtpmidid::build_options_t build_options;

--- a/include/rtpmidid/buildoptions.hpp.in
+++ b/include/rtpmidid/buildoptions.hpp.in
@@ -1,0 +1,20 @@
+#pragma once
+
+// clang-format off
+#cmakedefine LOG_LEVEL log_level_t::@LOG_LEVEL@
+// clang-format on
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL log_level_t::Debug
+#endif
+
+namespace rtpmidid {
+enum class log_level_t { Debug, Info, Warning, Error };
+
+
+struct build_options_t {
+  constexpr static int log_level = static_cast<int>(LOG_LEVEL);
+};
+} // namespace rtpmidid
+
+inline constexpr rtpmidid::build_options_t build_options;

--- a/include/rtpmidid/logger.hpp
+++ b/include/rtpmidid/logger.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 #include "formatterhelper.hpp"
+#include "buildoptions.hpp"
 #include <array>
 #include <iostream>
 
@@ -45,10 +46,13 @@ public:
                                   int lineno);
   void log_postamble(buffer_t::iterator it);
 
-  template <typename... Args>
-  constexpr void log(logger_level_t level, const char *filename, int lineno,
+  template <logger_level_t Level, typename... Args>
+  constexpr void log(const char *filename, int lineno,
                      FMT::format_string<Args...> message, Args... args) {
-    auto it = log_preamble(level, filename, lineno);
+    if constexpr(static_cast<int>(build_options.log_level) > static_cast<int>(Level)) {
+        return;
+    }
+    auto it = log_preamble(Level, filename, lineno);
 
     auto max_size = buffer.size() - (it - buffer.begin()) - 16;
     auto res =
@@ -93,16 +97,16 @@ void println(FMT::format_string<Args...> format, Args... args) {
 #endif
 
 #define DEBUG(...)                                                             \
-  ::rtpmidid::logger2.log(rtpmidid::logger_level_t::DEBUG, __FILE__, __LINE__, \
+  ::rtpmidid::logger2.log<rtpmidid::logger_level_t::DEBUG>(__FILE__, __LINE__, \
                           __VA_ARGS__)
 #define INFO(...)                                                              \
-  ::rtpmidid::logger2.log(rtpmidid::logger_level_t::INFO, __FILE__, __LINE__,  \
+  ::rtpmidid::logger2.log<rtpmidid::logger_level_t::INFO>(__FILE__, __LINE__,  \
                           __VA_ARGS__)
 #define ERROR(...)                                                             \
-  ::rtpmidid::logger2.log(rtpmidid::logger_level_t::ERROR, __FILE__, __LINE__, \
+  ::rtpmidid::logger2.log<rtpmidid::logger_level_t::ERROR>(__FILE__, __LINE__, \
                           __VA_ARGS__)
 #define WARNING(...)                                                           \
-  ::rtpmidid::logger2.log(rtpmidid::logger_level_t::WARNING, __FILE__,         \
+  ::rtpmidid::logger2.log<rtpmidid::logger_level_t::WARNING>(__FILE__,         \
                           __LINE__, __VA_ARGS__)
 
 #define WARNING_RATE_LIMIT(seconds, ...)                                       \

--- a/tests/test_case.hpp
+++ b/tests/test_case.hpp
@@ -102,7 +102,7 @@ public:
           tcase.fn();
           INFO("Test {} OK", tcase.name);
         } catch (const test_exception &e) {
-          ::rtpmidid::logger2.log(::rtpmidid::logger_level_t::ERROR, e.filename,
+          ::rtpmidid::logger2.log<::rtpmidid::logger_level_t::ERROR>(e.filename,
                                   e.line, "{}", e.error);
           ERROR("FAIL TEST {}: {}", tcase.name, e.what());
           errors += 1;


### PR DESCRIPTION
In one of my projects, the log gets quickly filled by debug messages. It would be great if there was a way to let the user configure the log level for app/library.

Here is a proposal for setting log level via cmake, but I could also imagine to set the level at runtime.