### PR TITLE
rtpclient: harden connect path against port=0 endpoints and +1 port collisions

### DIFF
--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -177,8 +177,66 @@ void rtpclient_t::state_resolve_next_ip_port() {
 }
 
 void rtpclient_t::state_connect_control() {
-  // Any, but could force the initial control port here
-  control_peer.open(network_address_list_t("::", local_base_port_str));
+  // Defensive: if a previous cycle (CK-timeout reconnect, etc.) left either
+  // peer bound, close them before re-allocating. Without this, the kernel
+  // could hand us the same ephemeral control port as last cycle, and our own
+  // surviving midi_peer would then hold control_port+1 — a false collision.
+  control_peer.close();
+  midi_peer.close();
+
+  // Speculatively bind both control_peer and midi_peer here, BEFORE telling
+  // the remote peer about us via IN. RTP-MIDI convention is
+  // midi_port = control_port + 1. The kernel's ephemeral allocator can give
+  // us a control_port whose +1 is owned by another process; retry with a
+  // fresh ephemeral pair up to MAX_PAIR_RETRIES.
+  //
+  // Retry only when local_base_port_str == "0" (ephemeral). A fixed user-
+  // configured local_udp_port that collides on +1 is a config error — fail
+  // with a clear message after one attempt.
+  static constexpr int MAX_PAIR_RETRIES = 5;
+  const bool ephemeral = (local_base_port_str == "0");
+  const int max_attempts = ephemeral ? MAX_PAIR_RETRIES : 1;
+
+  bool pair_acquired = false;
+  for (int attempt = 0; attempt < max_attempts; attempt++) {
+    control_peer.open(network_address_list_t("::", local_base_port_str));
+    if (!control_peer.is_open()) {
+      ERROR("Could not open control socket (attempt {}/{}): {}:{}",
+            attempt + 1, max_attempts,
+            resolve_next_dns_endpoint.hostname,
+            resolve_next_dns_endpoint.port);
+      continue;
+    }
+    local_base_port = control_peer.get_address().port();
+
+    midi_peer.open(
+        network_address_list_t("::", std::to_string(local_base_port + 1)));
+    if (midi_peer.is_open()) {
+      pair_acquired = true;
+      break;
+    }
+
+    if (ephemeral) {
+      WARNING("Acquired control port {} but midi port {} is unavailable "
+              "(likely owned by another process); retrying with a fresh "
+              "ephemeral pair (attempt {}/{})",
+              local_base_port, local_base_port + 1, attempt + 1, max_attempts);
+    } else {
+      ERROR("Could not bind midi port {} (configured local_udp_port={}); "
+            "pick a different port where both (port, port+1) are free.",
+            local_base_port + 1, local_base_port_str);
+    }
+    control_peer.close();
+  }
+
+  if (!pair_acquired) {
+    ERROR("Could not allocate adjacent control/midi port pair after {} "
+          "attempt(s); last tried control={} midi={}",
+          max_attempts, local_base_port, local_base_port + 1);
+    handle_event(ConnectFailed);
+    return;
+  }
+
   control_on_read_connection = control_peer.on_read.connect(
       [this](const packet_t &packet, const network_address_t &) {
         DEBUG("Data ready for control!");
@@ -186,18 +244,13 @@ void rtpclient_t::state_connect_control() {
         this->peer.data_ready(std::move(data), rtppeer_t::CONTROL_PORT);
       });
 
-  if (!control_peer.is_open()) {
-    ERROR("Could not connect {}:{} to control port",
-          resolve_next_dns_endpoint.hostname, resolve_next_dns_endpoint.port);
-    handle_event(ConnectFailed);
-    return;
-  }
-  local_base_port = control_peer.get_address().port();
-
   control_connected_event_connection =
       peer.status_change_event.connect([this](rtppeer_t::status_e status) {
         control_connected_event_connection.disconnect();
         if (status != rtppeer_t::CONTROL_CONNECTED) {
+          // Speculatively-bound midi_peer is still open here — release it
+          // before bouncing back to ResolveNextIpPort.
+          midi_peer.close();
           handle_event(ConnectFailed);
           return;
         }
@@ -211,6 +264,9 @@ void rtpclient_t::state_connect_control() {
   timer = poller.add_timer_event(connect_timeout, [this] {
     ERROR("Timeout connecting to control port");
     control_connected_event_connection.disconnect();
+    // Speculatively-bound midi_peer is still open here — release it
+    // before bouncing back to ResolveNextIpPort.
+    midi_peer.close();
     handle_event(ConnectFailed);
   });
 
@@ -219,12 +275,12 @@ void rtpclient_t::state_connect_control() {
 
 void rtpclient_t::state_connect_midi() {
   timer.disable();
-  midi_peer.open(
-      network_address_list_t("::", std::to_string(local_base_port + 1)));
 
+  // midi_peer was already opened in state_connect_control to guarantee the
+  // control+midi port pair is contiguous and both ports are bindable. Sanity
+  // guard in case the state machine is somehow re-entered out of order.
   if (!midi_peer.is_open()) {
-    ERROR("Could not connect {}:{} to midi port", midi_address.ip(),
-          midi_address.port() + 1);
+    ERROR("Internal: midi_peer should be open from state_connect_control");
     handle_event(ConnectFailed);
     return;
   }
@@ -262,6 +318,10 @@ void rtpclient_t::state_disconnect_control() {
   timer.disable();
   peer.send_goodbye(rtppeer_t::CONTROL_PORT);
   control_peer.close();
+  // With speculative midi_peer binding in state_connect_control, midi_peer is
+  // open by the time we reach this state via the ConnectMidi failure path.
+  // Without this close it stays bound for up to reconnect_timeout.
+  midi_peer.close();
   handle_event(ConnectFailed);
 }
 

--- a/lib/rtpclient.cpp
+++ b/lib/rtpclient.cpp
@@ -146,6 +146,21 @@ void rtpclient_t::state_resolve_next_ip_port() {
   if (resolve_next_dns_sockaddress_list_I !=
       resolve_next_dns_sockaddress_list.end()) {
     control_address = (*resolve_next_dns_sockaddress_list_I).dup();
+
+    // Guard: a resolved entry with destination port 0 means the endpoint
+    // had no port (getaddrinfo with service=NULL/""), or the resolver
+    // returned a malformed entry. Sending to :0 is permanently broken
+    // (kernel returns EINVAL on every sendto), so refuse and advance to
+    // the next resolved entry instead of letting the rtpclient_t enter a
+    // permanent retry loop.
+    if (control_address.port() == 0) {
+      ERROR("Refusing endpoint {} - destination port is 0 (missing or "
+            "invalid port in [connect_to] config)",
+            control_address.to_string());
+      handle_event(ResolveFailed);
+      return;
+    }
+
     midi_address =
         network_address_list_t(control_address.ip(),
                                std::to_string(control_address.port() + 1))

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -48,7 +48,11 @@ struct settings_t {
 
   struct connect_to_t {
     std::string hostname;
-    std::string port;
+    // Default to the standard RTP-MIDI control port (IANA: 5004). Without a
+    // default, an INI [connect_to] block missing `port=` left this empty,
+    // making getaddrinfo() resolve the endpoint to port 0; sendto() then
+    // failed EINVAL forever with no recovery path.
+    std::string port = "5004";
     std::string name;
     std::string local_udp_port;
   };


### PR DESCRIPTION
Hi! another small fix proposal:

## What this PR fixes

### Issue 1 — silent acceptance of `[connect_to]` blocks without `port=`

A `[connect_to]` block in the INI without an explicit `port=` line leaves `settings.connect_to[].port` as the empty string. That flows all the way through `main.cpp::setup_network_rtpmidi_listener` → `make_local_alsa_listener` → `local_alsa_listener_t::connect_to_remote_server` → `rtpclient_t::add_server_addresses({{hostname, ""}})`.

`state_resolve_next_ip_port` then calls `network_address_list_t(hostname, "")` → `getaddrinfo(hostname, NULL)`, which returns `sockaddr`s with **port 0**. `control_address.port()` ends up 0, and every subsequent `sendto()` fails with `EINVAL`:

```
[ERROR] udppeer.cpp:112 | Error sending to 169.254.9.204:0. This is UDP... so just lost! (Invalid argument)
[ERROR] rtpclient.cpp:87 | Client: Could not send all data to CONTROL_PORT. Sent -1. Invalid argument (22)
[ERROR] rtpclient.cpp:314 | Error at rtpclient_t. Will try to connect again in 30000ms
```

The state machine's retry path re-resolves the same broken endpoint, so the client loops forever.

**Fix (commit 1):** default `connect_to_t::port = "5004"` in `settings.hpp`. The IANA-registered RTP-MIDI control port matches what users almost certainly mean when they omit it (and what every published INI example uses for `[rtpmidi_announce]`).

### Issue 2 — `state_resolve_next_ip_port` should refuse port=0 entries

Even with the default in place, anyone constructing endpoints programmatically (or any other malformed config path) can still produce a resolved sockaddr with port 0. The state machine has no guard against this — it happily uses the entry, loops on EINVAL, and never recovers.

**Fix (commit 2):** in `state_resolve_next_ip_port`, refuse entries whose resolved port is 0, emit a clear ERROR, and advance to the next resolved sockaddr via `ResolveFailed`. Belt-and-braces alongside commit 1.

### Issue 3 — `state_connect_midi` collides with other processes on `control_port + 1`

`state_connect_control` opens `control_peer` at a kernel-assigned ephemeral (when `local_base_port_str == "0"`, which is what `local_alsa_listener_t` and `rtpmidiremotehandler` both pass for avahi-discovered peers). Then `state_connect_midi` calls `bind(local_base_port + 1)` for the MIDI socket.

The kernel ephemeral allocator can hand us a `control_port` whose `+1` is owned by another process. Production case we hit: another cuems daemon on the same host (`cuems-node-engine`) had a UDP source port at 48650 from an outbound NNG connection; rtpmidid was assigned `control = 48649` → MIDI bind on 48650 → `EADDRINUSE` → `ConnectFailed` → 30 s `reconnect_timeout`. On retry, kernel reuses the same ephemeral, same conflict — loop.

**Fix (commit 3):** speculatively bind both `control_peer` and `midi_peer` in `state_connect_control` *before* sending IN to the remote peer. If the `+1` bind fails, close `control_peer` and retry with a fresh ephemeral pair, up to `MAX_PAIR_RETRIES=5` times.

- Retry is gated on `local_base_port_str == "0"` (ephemeral mode). A user-configured fixed `local_udp_port` that collides on `+1` is a config error — fail after one attempt with a clear message (unchanged behavior).
- `state_connect_midi` no longer calls `midi_peer.open()` (it's already bound). An `is_open()` sanity guard catches state-machine misuse.
- The new "midi_peer is bound before IN" invariant required closing `midi_peer` on every exit from the not-yet-fully-connected window. Three places now call `midi_peer.close()`: the control connect_timeout timer lambda, the control status_change `!CONTROL_CONNECTED` branch, and `state_disconnect_control`.

## Verified

Reproduction on a real two-node cluster (one controller rtpmidi server, one node rtpmidi client driving an MTC chain through `cuems-videocomposer`):

| State | MTC outage on controller `systemctl restart rtpmidid` |
|---|---|
| Pre-fix | **permanent** (the loop in Issue 1 never recovers without manual restart on both ends) |
| With commit 1 only | **~33 s** (Issue 3 still hits, 30 s `reconnect_timeout` + handshake) |
| With all three commits | **~3 s** (just the natural avahi REMOVE + rediscover latency) |

Packet captures, journals, and aconnect snapshots from the test runs are available if useful for review.

## Backward compatibility

None broken.
- Existing INIs with `port=` set in `[connect_to]` are unaffected (commit 1 only sets the default).
- Existing endpoints with valid resolved ports are unaffected by commit 2 (only port=0 entries are refused).
- Existing connect paths see commit 3 as a transparent retry on a rare-but-real failure mode. With `local_udp_port` set to a fixed value, the one-attempt + ERROR behavior matches pre-patch.


Thanks!!
